### PR TITLE
Updated forum & blog links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -65,10 +65,10 @@
                   <a href="https://azerothcore-azerothcore-wotlk.getbadges.io/activity"><i class="fa fa-trophy" aria-hidden="true"></i> Get Badges </a>
                 </li> -->
                 <li>
-                  <a href="https://github.com/azerothcore/forum/issues?q=sort%3Aupdated-desc"><i class="fa fa-newspaper-o"></i> Forum</a>
+                  <a href="https://github.com/azerothcore/azerothcore-wotlk/discussions"><i class="fa fa-newspaper-o"></i> Forum</a>
                 </li> 
                 <li>
-                  <a href="http://azerothcore.altervista.org/wp/" target="_blank"><i class="fa fa-rss"></i> Blog</a>
+                  <a href="https://github.com/azerothcore/azerothcore-wotlk/discussions?discussions_q=category%3A%22News+%26+Blog%22" target="_blank"><i class="fa fa-rss"></i> Blog</a>
                 </li>
                 <li>
                   <a href="https://stackoverflow.com/questions/tagged/azerothcore?sort=newest" target="_blank"><i class="fa fa-stack-overflow"></i> StackOverflow</a>


### PR DESCRIPTION
I've updated the forum link with the new discussion board.

We can now deprecate the altervista blog too, since we can use a discussion category for it. It means that now we're 99% git hub powered !